### PR TITLE
Also accept plain string as command arg

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -8,7 +8,7 @@ export class Commands {
   ) {
     const commandName = `${extensionName}.openSpeedscope`;
 
-    const handler = async (uri?: vscode.Uri) => {
+    const handler = async (uri?: vscode.Uri | string) => {
       if (!uri) {
         const uris = await vscode.window.showOpenDialog({
           canSelectFiles: true,
@@ -20,6 +20,9 @@ export class Commands {
           return;
         }
         uri = uris[0];
+      }
+      if (typeof uri === "string") {
+        uri = vscode.Uri.file(uri);
       }
       await vscode.commands.executeCommand(
         "vscode.openWith",

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -1,4 +1,5 @@
 import * as assert from "assert";
+import * as path from "path";
 
 // You can import and use all API from the 'vscode' module
 // as well as import your extension to test it
@@ -49,5 +50,19 @@ suite("Extension Test Suite", () => {
       });
     });
     assert.strictEqual(success, true);
+  });
+
+  // openSpeedscope command should accept string argument as well as Uri
+  // this is necessary to support adding keybindings for example
+  test("Test openSpeedscope command with string argument", async () => {
+    const filePath = path.join(workspaceUri.path, "simple.prof");
+    await vscode.commands.executeCommand(
+      `${extensionName}.openSpeedscope`,
+      filePath,
+    );
+
+    // Testing if the extension activated
+    const extensionApi: PublicApi =
+      vscode.extensions.getExtension(extensionId)!.exports;
   });
 });


### PR DESCRIPTION
To resolve: https://github.com/sransara/speedscope-in-vscode/issues/1

Accept plain string as command arg to support setting keybindings to the command for example.