### PR TITLE
Support relative paths and some other usability improvements

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -20,9 +20,37 @@ export class Commands {
           return;
         }
         uri = uris[0];
-      }
-      if (typeof uri === "string") {
-        uri = vscode.Uri.file(uri);
+      } else if (typeof uri === "string" || uri instanceof String) {
+        if (uri.startsWith('.')) {
+          // Resolve relative path using workspace folders
+          if (!vscode.workspace.workspaceFolders) {
+            vscode.window.showErrorMessage(`No workspace found to resolve relative path: ${uri}`);
+            return;
+          }
+          // Try to find the file in any of the workspace folders
+          try {
+            uri = await Promise.any(
+              vscode.workspace.workspaceFolders.map(async (folder) => {
+                const maybeUri = vscode.Uri.joinPath(folder.uri, uri as string);
+                await vscode.workspace.fs.stat(maybeUri);
+                return maybeUri;
+              }),
+            );
+          }
+          catch (e) {
+            vscode.window.showErrorMessage(`File not found in any workspace: ${uri}`);
+            return;
+          }
+        }
+        else {
+          try {
+            uri = vscode.Uri.file(uri as string);
+            await vscode.workspace.fs.stat(uri);
+          } catch (e) {
+            vscode.window.showErrorMessage(`File not found: ${uri}`);
+            return;
+          }
+        }
       }
       await vscode.commands.executeCommand(
         "vscode.openWith",

--- a/src/editor-provider.ts
+++ b/src/editor-provider.ts
@@ -95,16 +95,25 @@ export class SpeedscopeEditorProvider
       if (e.clientEvent === "ready") {
         this.logger.info(`Speedscope view for ${document.uri} is ready`);
         this.logger.info(`Trying to load document: ${document.uri}`);
-        const docbytes = await vscode.workspace.fs.readFile(document.uri);
-        let filename = document.uri.path;
-        if (filename.includes("/")) {
-          filename = filename.slice(filename.lastIndexOf("/") + 1);
-        }
-        webviewPanel.webview.postMessage({
-          serverCommand: "openFile",
-          filename,
-          docbytes: new Uint8Array(docbytes),
-        });
+        await vscode.window.withProgress(
+          {
+            location: vscode.ProgressLocation.Notification,
+            title: "Loading profile...",
+            cancellable: false,
+          },
+          async () => {
+            const docbytes = await vscode.workspace.fs.readFile(document.uri);
+            let filename = document.uri.path;
+            if (filename.includes("/")) {
+              filename = filename.slice(filename.lastIndexOf("/") + 1);
+            }
+            webviewPanel.webview.postMessage({
+              serverCommand: "openFile",
+              filename,
+              docbytes: new Uint8Array(docbytes),
+            });
+          },
+        );
       } else if (e.clientCommand === "console") {
         const prefix = `speedscope view: console.${e.method}:`;
         switch (e.method) {

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -54,8 +54,21 @@ suite("Extension Test Suite", () => {
 
   // openSpeedscope command should accept string argument as well as Uri
   // this is necessary to support adding keybindings for example
-  test("Test openSpeedscope command with string argument", async () => {
+  test("Test openSpeedscope command with absolute path string argument", async () => {
     const filePath = path.join(workspaceUri.path, "simple.prof");
+    await vscode.commands.executeCommand(
+      `${extensionName}.openSpeedscope`,
+      filePath,
+    );
+
+    // Testing if the extension activated
+    const extensionApi: PublicApi =
+      vscode.extensions.getExtension(extensionId)!.exports;
+  });
+
+  // Test if the extension can open a file with a relative path
+  test("Test openSpeedscope command with relative path string argument", async () => {
+    const filePath = "./simple.prof";
     await vscode.commands.executeCommand(
       `${extensionName}.openSpeedscope`,
       filePath,


### PR DESCRIPTION
Support relative path in string argument. A relative path (any string argument starting with `.`) will be checked against all open workspaces to see if any of them have the file with specified relative path. Assumption is that usually there will be only one match.

Other usability improvements:

- Show notifcation error when file doesn't exist
- Show loader while the file is being transferred to the speescope frame
- Patch he speedscope app to show a more prominent loading bar