### PR TITLE
Fixed opening Node.js .cpuprofile files in editor

### DIFF
--- a/src/editor-provider.ts
+++ b/src/editor-provider.ts
@@ -136,6 +136,8 @@ export class SpeedscopeEditorProvider
         let fileUri: vscode.Uri;
         if (e.args.file.startsWith("/") || e.args.file[1] === ":") {
           fileUri = vscode.Uri.file(e.args.file);
+        } else if (e.args.file.startsWith("file://")) {
+          fileUri = vscode.Uri.file(e.args.file.replace("file://", ""));
         } else {
           // If relative path, assume it is relative to the current document
           fileUri = vscode.Uri.joinPath(document.uri, "..", e.args.file);


### PR DESCRIPTION
Hey @sransara, LOVE this extension - I use it all the time 😀 Here's a fix for a bug I run into all the time.

---

- if you generate a .cpuprofile file via `--cpu-prof`, open it with this extension and then try to Cmd+Click on a file, it'll try and open the wrong file
- this is because the paths are prefixed with `file://`, so the code drops into the else-block and we get prefixed with the current document.uri
- this solves that by detecting whether we have the file prefix, and then replacing it if so